### PR TITLE
Add Telegram preview to crawler list

### DIFF
--- a/useragent.go
+++ b/useragent.go
@@ -15,6 +15,7 @@ var (
 		"facebookexternalhit",
 		"PlurkBot",
 		"Twitterbot",
+		"TelegramBot",
 		"CloudFlare-AlwaysOnline",
 	}
 )


### PR DESCRIPTION
As reported in #3, the IM software Telegram's link preview is blocked for boards such as Gossiping. Thus suggest adding its user-agent to allow access.

