### PR TITLE
Add Pocket parser to crawler list

### DIFF
--- a/useragent.go
+++ b/useragent.go
@@ -14,6 +14,7 @@ var (
 		"MSNbot",
 		"facebookexternalhit",
 		"PlurkBot",
+		"PocketParser",
 		"Twitterbot",
 		"TelegramBot",
 		"CloudFlare-AlwaysOnline",


### PR DESCRIPTION
Allow parser of [Pocket](https://getpocket.com/), a read-it-later service, to access 18x boards.